### PR TITLE
Refactor Gimel Standalone Execution Flow / Logging

### DIFF
--- a/build/gimel_functions
+++ b/build/gimel_functions
@@ -35,6 +35,26 @@ check_error()
 	fi
 }
 
+#----------------------------function will check for error code & warn if failure----------------------------#
+
+#usage : check_warning <$?> <custom_error_code>
+#Example: Check_warning < pass $? from the shell command > < Custom Message for errorcode -gt 0 >
+
+
+check_warning()
+{
+
+        cmd_error_code=$1
+        pgm_exit_code=$2
+        pgm_exit_msg=$3
+        if  [ ${cmd_error_code} -gt 0 ]; then
+                write_log "WARNING ! ${cmd_error_code} ${pgm_exit_code} ${pgm_exit_msg}"
+        else
+                echo ""
+        fi
+}
+
+
 
 #----------------------------function will write the message to Console / Log File----------------------------#
 
@@ -47,3 +67,24 @@ write_log()
         echo ${to_be_logged}
 }
 
+#-----------------------------------Executes a Command--------------------------------------------------------#
+
+
+
+#Usage : run_cmd < The command to execute > 
+
+run_cmd()
+{
+       cmd=$1
+       if [ -z $2 ]; then 
+         fail_on_error="break_code"
+       else
+         fail_on_error=$2
+       fi 
+       write_log "Executing Command --> $1"
+       $cmd
+       error_code=$?
+       if [ ! $fail_on_error = "ignore_errors" ]; then
+           check_error $error_code "$cmd"
+       fi
+}

--- a/gimel-dataapi/gimel-quickstart/bootstrap.sh
+++ b/gimel-dataapi/gimel-quickstart/bootstrap.sh
@@ -1,135 +1,90 @@
 #!/usr/bin/env bash
 
-export gimel_repo_home=${GIMEL_HOME}
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+sh $GIMEL_HOME/quickstart/env
+source $GIMEL_HOME/build/gimel_functions
+
 export this_file=${0}
 export this_script=$(basename $this_file)
-#export this_time="$(date '+%Y%m%d%H%M%S')"
-#export log_dir=${gimel_repo_home}/.gimel_logs
-export standalone_dir=${gimel_repo_home}/gimel-dataapi/gimel-standalone
-#export log_file=${log_dir}/${this_script}.${this_time}
-export gimel_jar_name=gimel-sql-1.2.0-SNAPSHOT-uber.jar
-export final_jar=${standalone_dir}/lib/$gimel_jar_name
-export FLIGHTS_DATA_PATH=$GIMEL_HOME/gimel-dataapi/gimel-quickstart/flights
 
-#mkdir -p ${log_dir}
-
-#----------------------------function will write the message to Log File----------------------------#
-
-#Usage : write_log < Whatever message you need to log >
-
-write_log()
-{
-
-        msg=$1
-        echo "$(date '+%Y%m%d %H:%M:%S') : $msg"
-        #echo "" >> ${log_file}
-        #echo "$(date '+%Y%m%d %H:%M:%S') : $msg" >> ${log_file}
-}
-
-#----------------------------function will check for error code & exit if failure, else proceed further----------------------------#
-
-#usage : Run immediately after executing any shell command - with 3 arguments.
-#Example: check_error < pass $? from the shell command > < Error Code that you want the code to fail with > < Custom Message for errorcode -gt 0 >
-
-check_error()
-{
-
-        cmd_error_code=$1
-        pgm_exit_code=$2
-        pgm_exit_msg=$3
-        if  [ ${cmd_error_code} -gt 0 ]; then
-                write_log "Error ! Exiting Program ... ${cmd_error_code} ${pgm_exit_code} ${pgm_exit_msg}"
-                #send_email "FAILURE | ${this_script}"
-#                cd ${standalone_dir}/docker
-#                docker-compose down
-                exit ${pgm_exit_code}
-        else
-                echo ""
-        fi
-}
-
-check_warning()
-{
-
-        cmd_error_code=$1
-        pgm_exit_code=$2
-        pgm_exit_msg=$3
-        if  [ ${cmd_error_code} -gt 0 ]; then
-                write_log "WARNING ! ${cmd_error_code} ${pgm_exit_code} ${pgm_exit_msg}"
-        else
-                echo ""
-        fi
-}
+#----------------------------------- Starting Containers -------------------------------------------#
 
 write_log "Starting Docker Containers ...."
+
 cd ${standalone_dir}/docker
 export storages_list=$1
 if [ "$storages_list" == "all" ] || [ -z "$storages_list" ]; then
-  docker-compose up -d
+  run_cmd "docker-compose up -d"
 else
   export storages=$(printf '%s\n' "$storages_list" | tr ',' ' ')
-  docker-compose up -d $storages namenode datanode spark-master spark-worker-1
+  run_cmd "docker-compose up -d $storages namenode datanode spark-master spark-worker-1"
 fi
 
+#----------------------------------- Starting hive metastore ----------------------------------------#
+
+#this sleep is required to allow time for DBs to start though the container is started.
 sleep 10s
-docker-compose up -d hive-metastore
+run_cmd "docker-compose up -d hive-metastore"
 
-check_error $? 999 "Bootstrap Dockers - failure"
+#check_error $? 999 "Bootstrap Dockers - failure"
 
 sleep 10s
 
-#mkdir -p ${gimel_repo_home}/tmp
-#cd ${gimel_repo_home}/tmp
-#write_log "Getting the spark binary"
-#if [ ! -d "spark-2.2.1" ]; then
-#  curl -O http://mirrors.sorengard.com/apache/spark/spark-2.2.1/spark-2.2.1-bin-hadoop2.7.tgz
-#  check_error $? 999 "Getting Spark binary - failed"
-#  tar -xzf spark-2.2.1-bin-hadoop2.7.tgz
-#  mv spark-2.2.1-bin-hadoop2.7 spark-2.2.1
-#fi
+#-------------------------------------Unzip flights data ------------------------------------------------#
 
-write_log "Loading Flights data to HDFS"
+write_log "unzipping flights data ..."
 
 cd $GIMEL_HOME/gimel-dataapi/gimel-quickstart/
 if [ ! -d "flights" ]; then
-  unzip flights.zip
+  run_cmd "unzip flights.zip"
 fi
-docker exec -it namenode hadoop dfsadmin -safemode leave
-docker cp flights namenode:/root
-docker exec -it namenode hadoop fs -rm -r -f /flights
-docker exec -it namenode hadoop fs -put /root/flights /
 
-check_error $? 999 "Loading flights data to HDFS - failed"
 
-write_log "Bootstraping the Physical Storages"
+#-------------------------------------Copy the flights data to Docker images-------------------------------#
 
-#write_log "Bootstraping hive tables"
-#sh ${standalone_dir}/bin/bootstrap_hive.sh
-#check_error $? 999 "Bootstraping hive tables - failed"
+run_cmd "docker exec -it namenode hadoop dfsadmin -safemode leave"
+run_cmd "docker cp flights namenode:/root"
+run_cmd "docker exec -it namenode hadoop fs -rm -r -f /flights"
+run_cmd "docker exec -it namenode hadoop fs -put /root/flights /"
+
+
+#-------------------------------------Bootstraping the Physical Storages---------------------------------#
 
 write_log "Bootstraping HBase tables"
-sh ${standalone_dir}/bin/bootstrap_hbase.sh
-check_warning $? 999 "Bootstraping hbase tables - failed"
+run_cmd "sh ${standalone_dir}/bin/bootstrap_hbase.sh" ignore_errors
 
 write_log "Bootstraping Kafka topic"
-sh ${standalone_dir}/bin/bootstrap_kafka.sh
-check_warning $? 999 "Bootstraping kafka topic - failed"
-
-#export SPARK_HOME=${gimel_repo_home}/tmp/spark-2.2.1
-#sh $SPARK_HOME/bin/spark-shell --jars ${final_jar}
+run_cmd "sh ${standalone_dir}/bin/bootstrap_kafka.sh" ignore_errors
 
 sleep 10s
 
-write_log "Starting spark shell..."
+write_log "ALL STORAGE CONTAINERS - LAUNCHED"
 
-docker cp $final_jar spark-master:/root/
-docker cp hive-server:/opt/hive/conf/hive-site.xml $GIMEL_HOME/tmp/hive-site.xml
-docker cp $GIMEL_HOME/tmp/hive-site.xml spark-master:/spark/conf/
-docker cp hbase-master:/opt/hbase-1.2.6/conf/hbase-site.xml $GIMEL_HOME/tmp/hbase-site.xml
-docker cp $GIMEL_HOME/tmp/hbase-site.xml spark-master:/spark/conf/
-docker exec -it spark-master bash -c "export USER=$USER; export SPARK_HOME=/spark/; /spark/bin/spark-shell --jars /root/$gimel_jar_name"
+#-----------------------------------------Spark Shell--------------------------------------------------#
 
-check_error $? 999 "Starting spark shell - failed"
+write_log "Starting spark container..."
+
+run_cmd "docker cp $final_jar spark-master:/root/"
+run_cmd "docker cp hive-server:/opt/hive/conf/hive-site.xml $GIMEL_HOME/tmp/hive-site.xml"
+run_cmd "docker cp $GIMEL_HOME/tmp/hive-site.xml spark-master:/spark/conf/"
+run_cmd "docker cp hbase-master:/opt/hbase-1.2.6/conf/hbase-site.xml $GIMEL_HOME/tmp/hbase-site.xml"
+run_cmd "docker cp $GIMEL_HOME/tmp/hbase-site.xml spark-master:/spark/conf/"
+run_cmd "docker exec -it spark-master bash -c "export USER=$USER; export SPARK_HOME=/spark/; /spark/bin/spark-shell --jars /root/$gimel_jar_name""
+
 
 # send_email "${this_script} : Gimel Docker Up - Success"
 

--- a/gimel-dataapi/gimel-quickstart/bootstrap.sh
+++ b/gimel-dataapi/gimel-quickstart/bootstrap.sh
@@ -37,12 +37,12 @@ fi
 #----------------------------------- Starting hive metastore ----------------------------------------#
 
 #this sleep is required to allow time for DBs to start though the container is started.
-sleep 10s
+sleep 5s
 run_cmd "docker-compose up -d hive-metastore"
 
 #check_error $? 999 "Bootstrap Dockers - failure"
 
-sleep 10s
+sleep 5s
 
 #-------------------------------------Unzip flights data ------------------------------------------------#
 
@@ -51,11 +51,14 @@ write_log "unzipping flights data ..."
 cd $GIMEL_HOME/gimel-dataapi/gimel-quickstart/
 if [ ! -d "flights" ]; then
   run_cmd "unzip flights.zip"
+else 
+  write_log "Looks like Flights Data already exists.. Skipping Unzip !"
 fi
 
 
 #-------------------------------------Copy the flights data to Docker images-------------------------------#
 
+write_log "Attempting to Turn Off Safe Mode on Name Node..."
 run_cmd "docker exec -it namenode hadoop dfsadmin -safemode leave"
 run_cmd "docker cp flights namenode:/root"
 run_cmd "docker exec -it namenode hadoop fs -rm -r -f /flights"
@@ -70,7 +73,7 @@ run_cmd "sh ${standalone_dir}/bin/bootstrap_hbase.sh" ignore_errors
 write_log "Bootstraping Kafka topic"
 run_cmd "sh ${standalone_dir}/bin/bootstrap_kafka.sh" ignore_errors
 
-sleep 10s
+sleep 5s
 
 write_log "ALL STORAGE CONTAINERS - LAUNCHED"
 

--- a/gimel-dataapi/gimel-standalone/bin/bootstrap_hbase.sh
+++ b/gimel-dataapi/gimel-standalone/bin/bootstrap_hbase.sh
@@ -23,16 +23,34 @@ source ${GIMEL_HOME}/build/gimel_functions
 
 write_log "Started Script --> ${full_file}"
 
-write_log "Creating HBase tables"
+write_log "-----------------------------------------------------------------"
+write_log "If exists, - Disable HBase tables"
+write_log "-----------------------------------------------------------------"
 
 command_for_docker="echo \"
 disable 'flights:flights_lookup_carrier_code'
 disable 'flights:flights_lookup_cancellation_code'
-disable 'flights:flights_lookup_airline_id'
+disable 'flights:flights_lookup_airline_id'\" | hbase shell"
+
+docker exec -it hbase-master bash -c "${command_for_docker}"
+
+write_log "-----------------------------------------------------------------"
+write_log "If exists, - Drop HBase tables"
+write_log "-----------------------------------------------------------------"
+
+command_for_docker="echo \"
 drop 'flights:flights_lookup_carrier_code'
 drop 'flights:flights_lookup_cancellation_code'
 drop 'flights:flights_lookup_airline_id'
-drop_namespace 'flights'
+drop_namespace 'flights'\" | hbase shell"
+
+docker exec -it hbase-master bash -c "${command_for_docker}"
+
+write_log "-----------------------------------------------------------------"
+write_log "Create HBase tables"
+write_log "-----------------------------------------------------------------"
+
+command_for_docker="echo \"
 create_namespace 'flights'
 create 'flights:flights_lookup_carrier_code','flights'
 create 'flights:flights_lookup_cancellation_code','flights'

--- a/gimel-dataapi/gimel-standalone/bin/bootstrap_hbase.sh
+++ b/gimel-dataapi/gimel-standalone/bin/bootstrap_hbase.sh
@@ -1,43 +1,31 @@
 #!/usr/bin/env bash
 
-#----------------------------function will write the message to Log File----------------------------#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-#Usage : write_log < Whatever message you need to log >
+this_script=`basename $0`
+this_dir=`dirname $0`
+full_file="${this_dir}/${this_script}"
 
-write_log()
-{
+source ${GIMEL_HOME}/build/gimel_functions
 
-        msg=$1
-        echo "$(date '+%Y%m%d %H:%M:%S') : $msg"
-        #echo $1
-        #echo "" >> ${log_file}
-        #echo "$(date '+%Y%m%d %H:%M:%S') : $msg" >> ${log_file}
-}
-
-#----------------------------function will check for error code & exit if failure, else proceed further----------------------------#
-
-#usage : Run immediately after executing any shell command - with 3 arguments.
-#Example: check_error < pass $? from the shell command > < Error Code that you want the code to fail with > < Custom Message for errorcode -gt 0 >
-
-check_error()
-{
-
-        cmd_error_code=$1
-        pgm_exit_code=$2
-        pgm_exit_msg=$3
-        if  [ ${cmd_error_code} -gt 0 ]; then
-                write_log "Error ! Exiting Program ... ${cmd_error_code} ${pgm_exit_code} ${pgm_exit_msg}"
-#                cd ${standalone_dir}/docker
-#                docker-compose down
-                exit ${pgm_exit_code}
-        else
-                echo ""
-        fi
-}
+write_log "Started Script --> ${full_file}"
 
 write_log "Creating HBase tables"
 
-docker exec -it hbase-master bash -c "echo \"
+command_for_docker="echo \"
 disable 'flights:flights_lookup_carrier_code'
 disable 'flights:flights_lookup_cancellation_code'
 disable 'flights:flights_lookup_airline_id'
@@ -50,4 +38,6 @@ create 'flights:flights_lookup_carrier_code','flights'
 create 'flights:flights_lookup_cancellation_code','flights'
 create 'flights:flights_lookup_airline_id','flights'\" | hbase shell"
 
-check_error $? 999 "Creating HBase tables - failed"
+docker exec -it hbase-master bash -c "${command_for_docker}"
+
+write_log "Completed Script --> ${full_file}"

--- a/gimel-dataapi/gimel-standalone/bin/bootstrap_kafka.sh
+++ b/gimel-dataapi/gimel-standalone/bin/bootstrap_kafka.sh
@@ -1,43 +1,31 @@
 #!/usr/bin/env bash
 
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-#----------------------------function will write the message to Log File----------------------------#
+this_script=`basename $0`
+this_dir=`dirname $0`
+full_file="${this_dir}/${this_script}"
 
-#Usage : write_log < Whatever message you need to log >
+source ../../../build/gimel_functions
 
-write_log()
-{
-
-        msg=$1
-        echo "$(date '+%Y%m%d %H:%M:%S') : $msg"
-#        echo $1
-#        echo "" >> ${log_file}
-#        echo "$(date '+%Y%m%d %H:%M:%S') : $msg" >> ${log_file}
-}
-
-#----------------------------function will check for error code & exit if failure, else proceed further----------------------------#
-
-#usage : Run immediately after executing any shell command - with 3 arguments.
-#Example: check_error < pass $? from the shell command > < Error Code that you want the code to fail with > < Custom Message for errorcode -gt 0 >
-
-check_error()
-{
-
-        cmd_error_code=$1
-        pgm_exit_code=$2
-        pgm_exit_msg=$3
-        if  [ ${cmd_error_code} -gt 0 ]; then
-                write_log "Error ! Exiting Program ... ${cmd_error_code} ${pgm_exit_code} ${pgm_exit_msg}"
-#                cd ${standalone_dir}/docker
-#                docker-compose down
-                exit ${pgm_exit_code}
-        else
-                echo ""
-        fi
-}
+write_log "Started Script --> ${full_file}"
 
 write_log "Creating Kafka topic"
-docker exec -it kafka kafka-topics --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 3 --topic gimel.demo.flights
-docker exec -it kafka kafka-topics --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 3 --topic gimel.demo.flights.json
-docker exec -it kafka kafka-topics --zookeeper zookeeper:2181 --alter --topic gimel.demo.flights.json --config retention.ms=604800000
-check_error $? 999 "Creating Hive external tables - failed"
+run_cmd "docker exec -it kafka kafka-topics --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 3 --topic gimel.demo.flights"
+run_cmd "docker exec -it kafka kafka-topics --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 3 --topic gimel.demo.flights.json"
+run_cmd "docker exec -it kafka kafka-topics --zookeeper zookeeper:2181 --alter --topic gimel.demo.flights.json --config retention.ms=604800000"
+
+write_log "Completed Script --> ${full_file}"

--- a/gimel-dataapi/gimel-standalone/bin/bootstrap_kafka.sh
+++ b/gimel-dataapi/gimel-standalone/bin/bootstrap_kafka.sh
@@ -19,13 +19,21 @@ this_script=`basename $0`
 this_dir=`dirname $0`
 full_file="${this_dir}/${this_script}"
 
-source ../../../build/gimel_functions
+source ${GIMEL_HOME}/build/gimel_functions
 
 write_log "Started Script --> ${full_file}"
 
+write_log "-----------------------------------------------------------------"
+write_log "Deleting topic if exists..."
+write_log "-----------------------------------------------------------------"
+run_cmd "docker exec -it kafka kafka-topics --delete --zookeeper zookeeper:2181 --topic gimel.demo.flights"
+run_cmd "docker exec -it kafka kafka-topics --delete --zookeeper zookeeper:2181 --topic gimel.demo.flights.json"
+
+write_log "-----------------------------------------------------------------"
 write_log "Creating Kafka topic"
-run_cmd "docker exec -it kafka kafka-topics --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 3 --topic gimel.demo.flights"
-run_cmd "docker exec -it kafka kafka-topics --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 3 --topic gimel.demo.flights.json"
+write_log "-----------------------------------------------------------------"
+run_cmd "docker exec -it kafka kafka-topics --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 1 --topic gimel.demo.flights"
+run_cmd "docker exec -it kafka kafka-topics --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 1 --topic gimel.demo.flights.json"
 run_cmd "docker exec -it kafka kafka-topics --zookeeper zookeeper:2181 --alter --topic gimel.demo.flights.json --config retention.ms=604800000"
 
 write_log "Completed Script --> ${full_file}"

--- a/quickstart/env
+++ b/quickstart/env
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements. See the NOTICE file distributed with
@@ -15,20 +15,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-this_script=`basename $0`
-this_dir=`dirname $0`
-full_file="${this_dir}/${this_script}"
+this_dir=`basename $0`
+export GIMEL_HOME=${PWD}
+export gimel_repo_home=${GIMEL_HOME}
+export standalone_dir=${gimel_repo_home}/gimel-dataapi/gimel-standalone
+export gimel_jar_name=gimel-sql-1.2.0-SNAPSHOT-uber.jar
+export final_jar=${standalone_dir}/lib/$gimel_jar_name
+export FLIGHTS_DATA_PATH=$GIMEL_HOME/gimel-dataapi/gimel-quickstart/flights
 
-source ${GIMEL_HOME}/build/gimel_functions
 
-write_log "Started Script --> ${full_file}"
-
-export FLIGHTS_LOAD_DATA_SCRIPT=$GIMEL_HOME/gimel-dataapi/gimel-standalone/sql/flights_load_data.sql
-
-write_log "copying ${FLIGHTS_LOAD_DATA_SCRIPT} to HiveServer Docker Container..."
-run_cmd "docker cp $FLIGHTS_LOAD_DATA_SCRIPT hive-server:/root"
-
-write_log "Creating Hive external tables for CSV data..."
-run_cmd "docker exec -it hive-server bash -c "hive -f /root/flights_load_data.sql""
-
-write_log "Completed Script --> ${full_file}"

--- a/quickstart/gimel
+++ b/quickstart/gimel
@@ -1,50 +1,35 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-#set -x
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 export this_file=${0}
-export this_script_path="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+export this_dir=`dirname ${this_file}`
+source $this_dir/env
+
+export this_script_path=`dirname $0`
 echo ${this_script_path}
 cd ${this_script_path}
-cd ../
-export GIMEL_HOME=${PWD}
 
-#----------------------------function will write the message to Log File----------------------------#
-
-#Usage : write_log < Whatever message you need to log >
-
-write_log()
-{
-
-        msg=$1
-        #echo $1
-        #echo "" >> ${log_file}
-        echo "$(date '+%Y%m%d %H:%M:%S') : $msg"
-}
-
-#----------------------------function will check for error code & exit if failure, else proceed further----------------------------#
-
-#usage : Run immediately after executing any shell command - with 3 arguments.
-#Example: check_error < pass $? from the shell command > < Error Code that you want the code to fail with > < Custom Message for errorcode -gt 0 >
-
-check_error()
-{
-
-        cmd_error_code=$1
-        pgm_exit_code=$2
-        pgm_exit_msg=$3
-        if  [ ${cmd_error_code} -gt 0 ]; then
-                write_log "Error ! Exiting Program ... ${cmd_error_code} ${pgm_exit_code} ${pgm_exit_msg}"
-                exit ${pgm_exit_code}
-        else
-                echo ""
-        fi
-}
+source ${GIMEL_HOME}/build/gimel_functions
+sh ${this_dir}/env
 
 write_log "Current Directory is --> ${PWD}"
 
 write_log "Starting bootstrap for Gimel Data API"
 
-sh $GIMEL_HOME/gimel-dataapi/gimel-quickstart/bootstrap.sh "$*"
+run_cmd "sh $GIMEL_HOME/gimel-dataapi/gimel-quickstart/bootstrap.sh "$*""
 
 write_log "SUCCESS !!!"

--- a/quickstart/set-env
+++ b/quickstart/set-env
@@ -15,8 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-this_dir=`basename $0`
-export GIMEL_HOME=${PWD}
+if [ -z $GIMEL_HOME ]; then
+	export GIMEL_HOME=${PWD}
+fi
 export gimel_repo_home=${GIMEL_HOME}
 export standalone_dir=${gimel_repo_home}/gimel-dataapi/gimel-standalone
 export gimel_jar_name=gimel-sql-1.2.0-SNAPSHOT-uber.jar

--- a/quickstart/start-gimel
+++ b/quickstart/start-gimel
@@ -15,20 +15,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export this_file=${0}
-export this_dir=`dirname ${this_file}`
-source $this_dir/env
-export this_script_path=`dirname $0`
-cd ${this_script_path}
+export this_dir=`dirname $0`
+source $this_dir/set-env
 source ${GIMEL_HOME}/build/gimel_functions
 
-write_log "Starting bootstrap for Gimel Data API"
-#run_cmd "sh $GIMEL_HOME/gimel-dataapi/gimel-quickstart/bootstrap.sh "$*""
+write_log "Stop if any container is running already..."
+run_cmd "sh $GIMEL_HOME/quickstart/stop-gimel"
 
-sh $GIMEL_HOME/gimel-dataapi/gimel-quickstart/bootstrap.sh "$*"
-if [ $? -gt 0 ]; then
-    write_log "Encountered Error with Script | sh $GIMEL_HOME/gimel-dataapi/gimel-quickstart/bootstrap.sh "$*"
-    quickstart/start-gimel
-fi
+mkdir ${GIMEL_HOME}/tmp ${GIMEL_HOME}/lib
+
+write_log "Starting bootstrap for Gimel Data API"
+run_cmd "sh $GIMEL_HOME/gimel-dataapi/gimel-quickstart/bootstrap.sh "$*""
 
 write_log "SUCCESS !!!"

--- a/quickstart/start-gimel
+++ b/quickstart/start-gimel
@@ -20,10 +20,15 @@ export this_dir=`dirname ${this_file}`
 source $this_dir/env
 export this_script_path=`dirname $0`
 cd ${this_script_path}
-write_log "Current Directory is --> ${PWD}"
 source ${GIMEL_HOME}/build/gimel_functions
 
 write_log "Starting bootstrap for Gimel Data API"
-run_cmd "sh $GIMEL_HOME/gimel-dataapi/gimel-quickstart/bootstrap.sh "$*""
+#run_cmd "sh $GIMEL_HOME/gimel-dataapi/gimel-quickstart/bootstrap.sh "$*""
+
+sh $GIMEL_HOME/gimel-dataapi/gimel-quickstart/bootstrap.sh "$*"
+if [ $? -gt 0 ]; then
+    write_log "Encountered Error with Script | sh $GIMEL_HOME/gimel-dataapi/gimel-quickstart/bootstrap.sh "$*"
+    quickstart/start-gimel
+fi
 
 write_log "SUCCESS !!!"

--- a/quickstart/stop-gimel
+++ b/quickstart/stop-gimel
@@ -16,15 +16,21 @@
 # limitations under the License.
 
 export this_file=${0}
-export this_dir=`dirname ${this_file}`
-source $this_dir/env
-
-export this_script_path=`dirname $0`
-cd ${this_script_path}
-
+export this_script_path=`dirname ${this_file}`
+source $this_script_path/set-env
 source ${GIMEL_HOME}/build/gimel_functions
 
 cd ${GIMEL_HOME}/gimel-dataapi/gimel-standalone/docker
 write_log "Current Directory is --> ${PWD}"
-run_cmd "docker-compose stop -t 90"
+run_cmd "docker-compose stop -t 30"
+
+write_log "clearing the HDFS local data ..."
+run_cmd "rm -rf {GIMEL_HOME}/gimel-dataapi/gimel-quickstart/__MAXOSX"
+
+write_log "clearing the flights unzipped data..."
+run_cmd "rm -rf {GIMEL_HOME}/gimel-dataapi/gimel-quickstart/flights"
+
+write_log "clearing the directories ${GIMEL_HOME}/tmp ..."
+run_cmd "rm -rf ${GIMEL_HOME}/tmp"
+
 write_log "SUCCESS !!!"

--- a/quickstart/stop-gimel
+++ b/quickstart/stop-gimel
@@ -18,12 +18,17 @@
 export this_file=${0}
 export this_dir=`dirname ${this_file}`
 source $this_dir/env
+
 export this_script_path=`dirname $0`
+echo ${this_script_path}
 cd ${this_script_path}
-write_log "Current Directory is --> ${PWD}"
+
 source ${GIMEL_HOME}/build/gimel_functions
 
-write_log "Starting bootstrap for Gimel Data API"
-run_cmd "sh $GIMEL_HOME/gimel-dataapi/gimel-quickstart/bootstrap.sh "$*""
+cd ${GIMEL_HOME}/gimel-dataapi/gimel-standalone/docker
+
+write_log "Current Directory is --> ${PWD}"
+
+run_cmd "docker-compose stop"
 
 write_log "SUCCESS !!!"

--- a/quickstart/stop-gimel
+++ b/quickstart/stop-gimel
@@ -20,15 +20,11 @@ export this_dir=`dirname ${this_file}`
 source $this_dir/env
 
 export this_script_path=`dirname $0`
-echo ${this_script_path}
 cd ${this_script_path}
 
 source ${GIMEL_HOME}/build/gimel_functions
 
 cd ${GIMEL_HOME}/gimel-dataapi/gimel-standalone/docker
-
 write_log "Current Directory is --> ${PWD}"
-
-run_cmd "docker-compose stop"
-
+run_cmd "docker-compose stop -t 90"
 write_log "SUCCESS !!!"


### PR DESCRIPTION
- Starting Standalone
```bash
quickstart/start-gimel
```
- Stopping Standalone
```bash
quickstart/stop-gimel
```
- User Experience with Entire Flow 
```bash

LM-SJN-00876784:gimel dmohanakumarchan$ quickstart/start-gimel 
20180410 00:33:17 | Stop if any container is running already...
20180410 00:33:17 | Executing Command --> sh /Users/dmohanakumarchan/workspace/eclipse_luna/oss/gimel/quickstart/stop-gimel
20180410 00:33:17 | Current Directory is --> /Users/dmohanakumarchan/workspace/eclipse_luna/oss/gimel/gimel-dataapi/gimel-standalone/docker
20180410 00:33:17 | Executing Command --> docker-compose stop -t 30
Stopping hbase-regionserver        ... done
Stopping kibana                    ... done
Stopping hbase-master              ... done
Stopping spark-worker-1            ... done
Stopping spark-master              ... done
Stopping hive-server               ... done
Stopping datanode                  ... done
Stopping kafka                     ... done
Stopping namenode                  ... done
Stopping zookeeper                 ... done
Stopping elasticsearch             ... done
Stopping hive-metastore            ... done
Stopping hive-metastore-postgresql ... done
20180410 00:35:20 | Success | Stage | docker-compose stop -t 30
20180410 00:35:20 | clearing the HDFS local data ...
20180410 00:35:20 | Executing Command --> rm -rf {GIMEL_HOME}/gimel-dataapi/gimel-quickstart/__MAXOSX
20180410 00:35:20 | Success | Stage | rm -rf {GIMEL_HOME}/gimel-dataapi/gimel-quickstart/__MAXOSX
20180410 00:35:20 | clearing the flights unzipped data...
20180410 00:35:20 | Executing Command --> rm -rf {GIMEL_HOME}/gimel-dataapi/gimel-quickstart/flights
20180410 00:35:20 | Success | Stage | rm -rf {GIMEL_HOME}/gimel-dataapi/gimel-quickstart/flights
20180410 00:35:20 | clearing the directories /Users/dmohanakumarchan/workspace/eclipse_luna/oss/gimel/tmp ...
20180410 00:35:20 | Executing Command --> rm -rf /Users/dmohanakumarchan/workspace/eclipse_luna/oss/gimel/tmp
20180410 00:35:20 | Success | Stage | rm -rf /Users/dmohanakumarchan/workspace/eclipse_luna/oss/gimel/tmp
20180410 00:35:20 | SUCCESS !!!
20180410 00:35:20 | Success | Stage | sh /Users/dmohanakumarchan/workspace/eclipse_luna/oss/gimel/quickstart/stop-gimel
mkdir: /Users/dmohanakumarchan/workspace/eclipse_luna/oss/gimel/lib: File exists
20180410 00:35:20 | Starting bootstrap for Gimel Data API
20180410 00:35:20 | Executing Command --> sh /Users/dmohanakumarchan/workspace/eclipse_luna/oss/gimel/gimel-dataapi/gimel-quickstart/bootstrap.sh
20180410 00:35:20 | ------------------------------------------------------------------------------
20180410 00:35:20 | Starting Docker Containers ....
20180410 00:35:21 | ------------------------------------------------------------------------------
20180410 00:35:21 | Executing Command --> docker-compose up -d
Starting namenode                  ... done
Starting hive-metastore-postgresql ... done
Starting zookeeper                 ... done
Starting elasticsearch             ... done
Starting datanode                  ... done
Starting kibana                    ... done
Starting hive-metastore            ... done
Starting kafka                     ... done
Starting hive-server               ... done
Starting hive-server               ... done
Starting hbase-regionserver        ... done
Starting spark-master              ... done
Starting spark-worker-1            ... done
20180410 00:35:27 | Success | Stage | docker-compose up -d
20180410 00:35:27 | ------------------------------------------------------------------------------
20180410 00:35:27 | Staring Hive Metastore ....
20180410 00:35:27 | ------------------------------------------------------------------------------
20180410 00:35:32 | Executing Command --> docker-compose up -d hive-metastore
hive-metastore-postgresql is up-to-date
hive-metastore is up-to-date
20180410 00:35:33 | Success | Stage | docker-compose up -d hive-metastore
20180410 00:35:38 | ------------------------------------------------------------------------------
20180410 00:35:38 | unzipping flights data ...
20180410 00:35:38 | ------------------------------------------------------------------------------
20180410 00:35:38 | Looks like Flights Data already exists.. Skipping Unzip !
20180410 00:35:38 | ------------------------------------------------------------------------------
20180410 00:35:38 | Attempting to Turn Off Safe Mode on Name Node..
20180410 00:35:38 | ------------------------------------------------------------------------------
20180410 00:35:38 | Attempting to Turn Off Safe Mode on Name Node...
20180410 00:35:38 | Executing Command --> docker exec -it namenode hadoop dfsadmin -safemode leave
DEPRECATED: Use of this script to execute hdfs command is deprecated.
Instead use the hdfs command for it.

Safe mode is OFF
20180410 00:35:47 | Success | Stage | docker exec -it namenode hadoop dfsadmin -safemode leave
20180410 00:35:47 | ------------------------------------------------------------------------------
20180410 00:35:47 | Copy the flights data to Docker images ...
20180410 00:35:47 | ------------------------------------------------------------------------------
20180410 00:35:47 | Executing Command --> docker cp flights namenode:/root
20180410 00:35:50 | Success | Stage | docker cp flights namenode:/root
20180410 00:35:50 | Executing Command --> docker exec -it namenode hadoop fs -rm -r -f /flights
18/04/10 07:36:01 INFO fs.TrashPolicyDefault: Namenode trash configuration: Deletion interval = 0 minutes, Emptier interval = 0 minutes.
Deleted /flights
20180410 00:35:56 | Success | Stage | docker exec -it namenode hadoop fs -rm -r -f /flights
20180410 00:35:56 | Executing Command --> docker exec -it namenode hadoop fs -put /root/flights /
20180410 00:36:04 | Success | Stage | docker exec -it namenode hadoop fs -put /root/flights /
20180410 00:36:04 | ------------------------------------------------------------------------------
20180410 00:36:04 | Bootstraping the Physical Storage - HBASE ....
20180410 00:36:04 | ------------------------------------------------------------------------------
20180410 00:36:04 | Executing Command --> sh /Users/dmohanakumarchan/workspace/eclipse_luna/oss/gimel/gimel-dataapi/gimel-standalone/bin/bootstrap_hbase.sh
20180410 00:36:04 | Started Script --> /Users/dmohanakumarchan/workspace/eclipse_luna/oss/gimel/gimel-dataapi/gimel-standalone/bin/bootstrap_hbase.sh
20180410 00:36:04 | -----------------------------------------------------------------
20180410 00:36:04 | If exists, - Disable HBase tables
20180410 00:36:04 | -----------------------------------------------------------------
2018-04-10 07:36:14,776 WARN  [main] util.NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
HBase Shell; enter 'help<RETURN>' for list of supported commands.
Type "exit<RETURN>" to leave the HBase Shell
Version 1.2.6, rUnknown, Mon May 29 02:25:32 CDT 2017


disable 'flights:flights_lookup_carrier_code'

ERROR: org.apache.hadoop.hbase.PleaseHoldException: Master is initializing
	at org.apache.hadoop.hbase.master.HMaster.checkInitialized(HMaster.java:2379)
	at org.apache.hadoop.hbase.master.HMaster.disableTable(HMaster.java:2068)
	at org.apache.hadoop.hbase.master.MasterRpcServices.disableTable(MasterRpcServices.java:550)
	at org.apache.hadoop.hbase.protobuf.generated.MasterProtos$MasterService$2.callBlockingMethod(MasterProtos.java:55678)
	at org.apache.hadoop.hbase.ipc.RpcServer.call(RpcServer.java:2196)
	at org.apache.hadoop.hbase.ipc.CallRunner.run(CallRunner.java:112)
	at org.apache.hadoop.hbase.ipc.RpcExecutor.consumerLoop(RpcExecutor.java:133)
	at org.apache.hadoop.hbase.ipc.RpcExecutor$1.run(RpcExecutor.java:108)
	at java.lang.Thread.run(Thread.java:748)

Here is some help for this command:
Start disable of named table:
  hbase> disable 't1'
  hbase> disable 'ns1:t1'


disable 'flights:flights_lookup_cancellation_code'
0 row(s) in 2.3960 seconds

disable 'flights:flights_lookup_airline_id'
0 row(s) in 2.2440 seconds

20180410 00:36:19 | -----------------------------------------------------------------
20180410 00:36:19 | If exists, - Drop HBase tables
20180410 00:36:19 | -----------------------------------------------------------------
2018-04-10 07:36:28,581 WARN  [main] util.NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
HBase Shell; enter 'help<RETURN>' for list of supported commands.
Type "exit<RETURN>" to leave the HBase Shell
Version 1.2.6, rUnknown, Mon May 29 02:25:32 CDT 2017


drop 'flights:flights_lookup_carrier_code'

ERROR: Table flights:flights_lookup_carrier_code is enabled. Disable it first.

Here is some help for this command:
Drop the named table. Table must first be disabled:
  hbase> drop 't1'
  hbase> drop 'ns1:t1'


drop 'flights:flights_lookup_cancellation_code'
0 row(s) in 1.3170 seconds

drop 'flights:flights_lookup_airline_id'
0 row(s) in 1.2480 seconds

drop_namespace 'flights'

ERROR: org.apache.hadoop.hbase.constraint.ConstraintException: Only empty namespaces can be removed. Namespace flights has 1 tables
	at org.apache.hadoop.hbase.master.TableNamespaceManager.remove(TableNamespaceManager.java:200)
	at org.apache.hadoop.hbase.master.HMaster.deleteNamespace(HMaster.java:2578)
	at org.apache.hadoop.hbase.master.MasterRpcServices.deleteNamespace(MasterRpcServices.java:490)
	at org.apache.hadoop.hbase.protobuf.generated.MasterProtos$MasterService$2.callBlockingMethod(MasterProtos.java:55730)
	at org.apache.hadoop.hbase.ipc.RpcServer.call(RpcServer.java:2196)
	at org.apache.hadoop.hbase.ipc.CallRunner.run(CallRunner.java:112)
	at org.apache.hadoop.hbase.ipc.RpcExecutor.consumerLoop(RpcExecutor.java:133)
	at org.apache.hadoop.hbase.ipc.RpcExecutor$1.run(RpcExecutor.java:108)
	at java.lang.Thread.run(Thread.java:748)

Here is some help for this command:
Drop the named namespace. The namespace must be empty.


20180410 00:36:27 | -----------------------------------------------------------------
20180410 00:36:27 | Create HBase tables
20180410 00:36:27 | -----------------------------------------------------------------
2018-04-10 07:36:36,107 WARN  [main] util.NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
HBase Shell; enter 'help<RETURN>' for list of supported commands.
Type "exit<RETURN>" to leave the HBase Shell
Version 1.2.6, rUnknown, Mon May 29 02:25:32 CDT 2017


create_namespace 'flights'

ERROR: org.apache.hadoop.hbase.NamespaceExistException: flights
	at org.apache.hadoop.hbase.master.TableNamespaceManager.create(TableNamespaceManager.java:158)
	at org.apache.hadoop.hbase.master.TableNamespaceManager.create(TableNamespaceManager.java:133)
	at org.apache.hadoop.hbase.master.HMaster.createNamespace(HMaster.java:2547)
	at org.apache.hadoop.hbase.master.MasterRpcServices.createNamespace(MasterRpcServices.java:450)
	at org.apache.hadoop.hbase.protobuf.generated.MasterProtos$MasterService$2.callBlockingMethod(MasterProtos.java:55728)
	at org.apache.hadoop.hbase.ipc.RpcServer.call(RpcServer.java:2196)
	at org.apache.hadoop.hbase.ipc.CallRunner.run(CallRunner.java:112)
	at org.apache.hadoop.hbase.ipc.RpcExecutor.consumerLoop(RpcExecutor.java:133)
	at org.apache.hadoop.hbase.ipc.RpcExecutor$1.run(RpcExecutor.java:108)
	at java.lang.Thread.run(Thread.java:748)

Here is some help for this command:
Create namespace; pass namespace name,
and optionally a dictionary of namespace configuration.
Examples:

  hbase> create_namespace 'ns1'
  hbase> create_namespace 'ns1', {'PROPERTY_NAME'=>'PROPERTY_VALUE'}


create 'flights:flights_lookup_carrier_code','flights'

ERROR: Table already exists: flights:flights_lookup_carrier_code!

Here is some help for this command:
Creates a table. Pass a table name, and a set of column family
specifications (at least one), and, optionally, table configuration.
Column specification can be a simple string (name), or a dictionary
(dictionaries are described below in main help output), necessarily 
including NAME attribute. 
Examples:

Create a table with namespace=ns1 and table qualifier=t1
  hbase> create 'ns1:t1', {NAME => 'f1', VERSIONS => 5}

Create a table with namespace=default and table qualifier=t1
  hbase> create 't1', {NAME => 'f1'}, {NAME => 'f2'}, {NAME => 'f3'}
  hbase> # The above in shorthand would be the following:
  hbase> create 't1', 'f1', 'f2', 'f3'
  hbase> create 't1', {NAME => 'f1', VERSIONS => 1, TTL => 2592000, BLOCKCACHE => true}
  hbase> create 't1', {NAME => 'f1', CONFIGURATION => {'hbase.hstore.blockingStoreFiles' => '10'}}
  
Table configuration options can be put at the end.
Examples:

  hbase> create 'ns1:t1', 'f1', SPLITS => ['10', '20', '30', '40']
  hbase> create 't1', 'f1', SPLITS => ['10', '20', '30', '40']
  hbase> create 't1', 'f1', SPLITS_FILE => 'splits.txt', OWNER => 'johndoe'
  hbase> create 't1', {NAME => 'f1', VERSIONS => 5}, METADATA => { 'mykey' => 'myvalue' }
  hbase> # Optionally pre-split the table into NUMREGIONS, using
  hbase> # SPLITALGO ("HexStringSplit", "UniformSplit" or classname)
  hbase> create 't1', 'f1', {NUMREGIONS => 15, SPLITALGO => 'HexStringSplit'}
  hbase> create 't1', 'f1', {NUMREGIONS => 15, SPLITALGO => 'HexStringSplit', REGION_REPLICATION => 2, CONFIGURATION => {'hbase.hregion.scan.loadColumnFamiliesOnDemand' => 'true'}}
  hbase> create 't1', {NAME => 'f1', DFS_REPLICATION => 1}

You can also keep around a reference to the created table:

  hbase> t1 = create 't1', 'f1'

Which gives you a reference to the table named 't1', on which you can then
call methods.


create 'flights:flights_lookup_cancellation_code','flights'
0 row(s) in 1.2300 seconds

Hbase::Table - flights:flights_lookup_cancellation_code
create 'flights:flights_lookup_airline_id','flights'
0 row(s) in 1.2350 seconds

Hbase::Table - flights:flights_lookup_airline_id
20180410 00:36:34 | Completed Script --> /Users/dmohanakumarchan/workspace/eclipse_luna/oss/gimel/gimel-dataapi/gimel-standalone/bin/bootstrap_hbase.sh
20180410 00:36:34 | ------------------------------------------------------------------------------
20180410 00:36:34 | Bootstraping the Physical Storage - KAFKA ....
20180410 00:36:34 | ------------------------------------------------------------------------------
20180410 00:36:34 | Executing Command --> sh /Users/dmohanakumarchan/workspace/eclipse_luna/oss/gimel/gimel-dataapi/gimel-standalone/bin/bootstrap_kafka.sh
20180410 00:36:34 | Started Script --> /Users/dmohanakumarchan/workspace/eclipse_luna/oss/gimel/gimel-dataapi/gimel-standalone/bin/bootstrap_kafka.sh
20180410 00:36:34 | -----------------------------------------------------------------
20180410 00:36:34 | Deleting topic if exists...
20180410 00:36:34 | -----------------------------------------------------------------
20180410 00:36:34 | Executing Command --> docker exec -it kafka kafka-topics --delete --zookeeper zookeeper:2181 --topic gimel.demo.flights
Topic gimel.demo.flights is marked for deletion.
Note: This will have no impact if delete.topic.enable is not set to true.
20180410 00:36:36 | Success | Stage | docker exec -it kafka kafka-topics --delete --zookeeper zookeeper:2181 --topic gimel.demo.flights
20180410 00:36:36 | Executing Command --> docker exec -it kafka kafka-topics --delete --zookeeper zookeeper:2181 --topic gimel.demo.flights.json
Topic gimel.demo.flights.json is marked for deletion.
Note: This will have no impact if delete.topic.enable is not set to true.
20180410 00:36:37 | Success | Stage | docker exec -it kafka kafka-topics --delete --zookeeper zookeeper:2181 --topic gimel.demo.flights.json
20180410 00:36:37 | -----------------------------------------------------------------
20180410 00:36:37 | Creating Kafka topic
20180410 00:36:37 | -----------------------------------------------------------------
20180410 00:36:37 | Executing Command --> docker exec -it kafka kafka-topics --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 1 --topic gimel.demo.flights
WARNING: Due to limitations in metric names, topics with a period ('.') or underscore ('_') could collide. To avoid issues it is best to use either, but not both.
Created topic "gimel.demo.flights".
20180410 00:36:38 | Success | Stage | docker exec -it kafka kafka-topics --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 1 --topic gimel.demo.flights
20180410 00:36:38 | Executing Command --> docker exec -it kafka kafka-topics --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 1 --topic gimel.demo.flights.json
WARNING: Due to limitations in metric names, topics with a period ('.') or underscore ('_') could collide. To avoid issues it is best to use either, but not both.
Created topic "gimel.demo.flights.json".
20180410 00:36:39 | Success | Stage | docker exec -it kafka kafka-topics --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 1 --topic gimel.demo.flights.json
20180410 00:36:39 | Executing Command --> docker exec -it kafka kafka-topics --zookeeper zookeeper:2181 --alter --topic gimel.demo.flights.json --config retention.ms=604800000
WARNING: Altering topic configuration from this script has been deprecated and may be removed in future releases.
         Going forward, please use kafka-configs.sh for this functionality
Updated config for topic "gimel.demo.flights.json".
20180410 00:36:40 | Success | Stage | docker exec -it kafka kafka-topics --zookeeper zookeeper:2181 --alter --topic gimel.demo.flights.json --config retention.ms=604800000
20180410 00:36:40 | Completed Script --> /Users/dmohanakumarchan/workspace/eclipse_luna/oss/gimel/gimel-dataapi/gimel-standalone/bin/bootstrap_kafka.sh
20180410 00:36:45 | ------------------------------------------------------------------------------
20180410 00:36:45 | Bootstraping the Physical Storage - HIVE ....
20180410 00:36:45 | ------------------------------------------------------------------------------
20180410 00:36:45 | Executing Command --> sh /Users/dmohanakumarchan/workspace/eclipse_luna/oss/gimel/gimel-dataapi/gimel-standalone/bin/bootstrap_hive.sh
20180410 00:36:45 | Started Script --> /Users/dmohanakumarchan/workspace/eclipse_luna/oss/gimel/gimel-dataapi/gimel-standalone/bin/bootstrap_hive.sh
20180410 00:36:45 | -----------------------------------------------------------------
20180410 00:36:46 | Executing /Users/dmohanakumarchan/workspace/eclipse_luna/oss/gimel/gimel-dataapi/gimel-standalone/sql/bootstrap_kafka.sql ...
20180410 00:36:46 | -----------------------------------------------------------------
20180410 00:36:46 | copying /Users/dmohanakumarchan/workspace/eclipse_luna/oss/gimel/gimel-dataapi/gimel-standalone/sql/bootstrap_kafka.sql to HiveServer Docker Container...
20180410 00:36:46 | Executing Command --> docker cp /Users/dmohanakumarchan/workspace/eclipse_luna/oss/gimel/gimel-dataapi/gimel-standalone/sql/bootstrap_kafka.sql hive-server:/root
20180410 00:36:46 | Success | Stage | docker cp /Users/dmohanakumarchan/workspace/eclipse_luna/oss/gimel/gimel-dataapi/gimel-standalone/sql/bootstrap_kafka.sql hive-server:/root
20180410 00:36:46 | Executing Command --> docker exec -it hive-server hive -f /root/bootstrap_kafka.sql
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/opt/hive/lib/log4j-slf4j-impl-2.4.1.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/opt/hadoop-2.7.1/share/hadoop/common/lib/slf4j-log4j12-1.7.10.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.apache.logging.slf4j.Log4jLoggerFactory]

Logging initialized using configuration in file:/opt/hive/conf/hive-log4j2.properties Async: true
OK
Time taken: 0.821 seconds
OK
Time taken: 0.126 seconds
FAILED: Execution Error, return code 1 from org.apache.hadoop.hive.ql.exec.DDLTask. AlreadyExistsException(message:Table flights_kafka already exists)
20180410 00:36:52 | Error | Stage | docker exec -it hive-server hive -f /root/bootstrap_kafka.sql
20180410 00:36:52 | ------------------------------------------------------------------------------
20180410 00:36:52 | ALL STORAGE CONTAINERS - LAUNCHED
20180410 00:36:52 | ------------------------------------------------------------------------------
20180410 00:36:52 |
20180410 00:36:52 |
20180410 00:36:52 | ------------------------------------------------------------------------------
20180410 00:36:52 | Setting up spark container...
20180410 00:36:52 | ------------------------------------------------------------------------------
20180410 00:36:52 | Executing Command --> docker cp /Users/dmohanakumarchan/workspace/eclipse_luna/oss/gimel/gimel-dataapi/gimel-standalone/lib/gimel-sql-1.2.0-SNAPSHOT-uber.jar spark-master:/root/
20180410 00:36:55 | Success | Stage | docker cp /Users/dmohanakumarchan/workspace/eclipse_luna/oss/gimel/gimel-dataapi/gimel-standalone/lib/gimel-sql-1.2.0-SNAPSHOT-uber.jar spark-master:/root/
20180410 00:36:55 | Executing Command --> docker cp hive-server:/opt/hive/conf/hive-site.xml /Users/dmohanakumarchan/workspace/eclipse_luna/oss/gimel/tmp/hive-site.xml
20180410 00:36:55 | Success | Stage | docker cp hive-server:/opt/hive/conf/hive-site.xml /Users/dmohanakumarchan/workspace/eclipse_luna/oss/gimel/tmp/hive-site.xml
20180410 00:36:55 | Executing Command --> docker cp /Users/dmohanakumarchan/workspace/eclipse_luna/oss/gimel/tmp/hive-site.xml spark-master:/spark/conf/
20180410 00:36:56 | Success | Stage | docker cp /Users/dmohanakumarchan/workspace/eclipse_luna/oss/gimel/tmp/hive-site.xml spark-master:/spark/conf/
20180410 00:36:56 | Executing Command --> docker cp hbase-master:/opt/hbase-1.2.6/conf/hbase-site.xml /Users/dmohanakumarchan/workspace/eclipse_luna/oss/gimel/tmp/hbase-site.xml
20180410 00:36:56 | Success | Stage | docker cp hbase-master:/opt/hbase-1.2.6/conf/hbase-site.xml /Users/dmohanakumarchan/workspace/eclipse_luna/oss/gimel/tmp/hbase-site.xml
20180410 00:36:56 | Executing Command --> docker cp /Users/dmohanakumarchan/workspace/eclipse_luna/oss/gimel/tmp/hbase-site.xml spark-master:/spark/conf/
20180410 00:36:56 | Success | Stage | docker cp /Users/dmohanakumarchan/workspace/eclipse_luna/oss/gimel/tmp/hbase-site.xml spark-master:/spark/conf/
20180410 00:36:56 |
20180410 00:36:56 |
20180410 00:36:56 | ----------------------------------------------------------------------------------------------------------------------
20180410 00:36:56 | ---------- Bootstrap Complete | Ready to use Gimel | Use below command to start spark --------------------------------
20180410 00:36:56 | ----------------------------------------------------------------------------------------------------------------------
20180410 00:36:56 |
20180410 00:36:56 |
20180410 00:36:56 | docker exec -it spark-master bash -c "export USER=$USER; export SPARK_HOME=/spark/; /spark/bin/spark-shell --jars /root/$gimel_jar_name"
20180410 00:36:56 |
20180410 00:36:56 | Success | Stage | sh /Users/dmohanakumarchan/workspace/eclipse_luna/oss/gimel/gimel-dataapi/gimel-quickstart/bootstrap.sh
20180410 00:36:56 | SUCCESS !!!
LM-SJN-00876784:gimel dmohanakumarchan$ 


```